### PR TITLE
Change drush branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ First get Composer:
 
 Now install the latest Drush:
 
-    composer global require drush/drush:dev-master
+    composer global require drush/drush
 
 And add it to the path:
 


### PR DESCRIPTION
Couldn't clone dev-master branch, simply removed branch option to install latest (6.5 at the minute).