### PR TITLE
Fix #58

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,9 @@ Vagrant.configure("2") do |config|
         "pgpasswd" => "pass",
       }
   end
+  config.vm.provision :shell,
+    :inline => "chown www-data:www-data /var/ckan/wsgi_app.py && chown -R www-data:www-data /home/co/ckan"
+  # above just a cheat to prevent issue #58. Should do this in puppet in future
 
   # Allow local machines to view the VM
   config.vm.network "private_network", ip: "192.168.11.11"

--- a/puppet/modules/dgu_ckan/manifests/init.pp
+++ b/puppet/modules/dgu_ckan/manifests/init.pp
@@ -504,6 +504,8 @@ class dgu_ckan {
   }
   file {$ckan_wsgi_script:
     content => template('dgu_ckan/wsgi_app.py.erb'),
+    owner   => 'www-data',
+    group   => 'www-data'
   }
   exec {'a2ensite ckan.conf':
     require   => [

--- a/puppet/modules/dgu_ckan/manifests/init.pp
+++ b/puppet/modules/dgu_ckan/manifests/init.pp
@@ -503,9 +503,7 @@ class dgu_ckan {
     notify  => Exec['a2ensite ckan.conf'],
   }
   file {$ckan_wsgi_script:
-    content => template('dgu_ckan/wsgi_app.py.erb'),
-    owner   => 'www-data',
-    group   => 'www-data'
+    content => template('dgu_ckan/wsgi_app.py.erb')
   }
   exec {'a2ensite ckan.conf':
     require   => [


### PR DESCRIPTION
Sorry, it's a little hacky, I meant to use Puppet to do this but fell down a rabbit hole so just fixed this the fastest way I could think of.  It ought to work by editing the file definitions inside init.pp and ensuring that the user and group of `$ckan_wsgi_script` and `$ckan_virtualenv` are www-data:www-data. However this just runs a shell provisioner after puppet finishes and executes `chown www-data:www-data /var/ckan/wsgi_app.py && chown -R www-data:www-data /home/co/ckan`. Closes #58 as far as I'm concerned. I have a smooth install with this fix.