### PR TITLE
Correct git reference to python module

### DIFF
--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -19,7 +19,7 @@ mod "datagovuk/solr", '2.0.7',
 # commit e92de3dee9c55d5 is actually v1.9.5
 mod "datagovuk/python",
    :git => "https://github.com/stankevich/puppet-python",
-   :ref => 'e92de3dee9c55d5'
+   :ref => 'eb52429dbf78778a4871169571a744bff44a6287'
 
 mod "datagovuk/dgu_ckan",
    :path => "/vagrant/puppet/modules/dgu_ckan"


### PR DESCRIPTION
The previous reference wasn't resolving to a commit which meant the setup was failing.

This reference points to actual 1.9.5 release of the module. The setup process ran cleanly for me after I made this change.