### PR TITLE
Change git clone SSH commands to use HTTPS instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ NB This setup does not work with a Windows host machine (since it relies on symb
 
 Before creating the virtual machine, clone this repo to the host machine and switch to the 'togo' branch:
 
-    git clone git@github.com:datagovuk/dgu-vagrant-puppet
+    git clone https://github.com/datagovuk/dgu-vagrant-puppet
     cd dgu-vagrant-puppet
     git checkout togo
 
@@ -127,7 +127,7 @@ Clone this repo to the machine in /vagrant (to match the vagrant install) and sw
 
     mkdir /vagrant
     cd /vagrant
-    git clone git@github.com:datagovuk/dgu-vagrant-puppet
+    git clone https://github.com/datagovuk/dgu-vagrant-puppet
     cd /vagrant/dgu-vagrant-puppet
     git checkout togo
 

--- a/src/git_clone_all.sh
+++ b/src/git_clone_all.sh
@@ -3,99 +3,99 @@
 # git clone steps
 # ---------------
 
-git clone	git@github.com:datagovuk/ckan
+git clone	https://github.com/datagovuk/ckan
 cd ckan
 git checkout release-v2.2-dgu
-git remote add okfn git@github.com:okfn/ckan
+git remote add okfn https://github.com/okfn/ckan
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-archiver
+git clone	https://github.com/datagovuk/ckanext-archiver
 cd ckanext-archiver
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-certificates
+git clone	https://github.com/datagovuk/ckanext-certificates
 cd ckanext-certificates
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-datapreview
+git clone	https://github.com/datagovuk/ckanext-datapreview
 cd ckanext-datapreview
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-dcat
+git clone	https://github.com/datagovuk/ckanext-dcat
 cd ckanext-dcat
 git checkout dgu
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-dgu
+git clone	https://github.com/datagovuk/ckanext-dgu
 cd ckanext-dgu
 git checkout master
 ln -s ../commit-msg.githook ./.git/hooks/commit-msg
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-dgu-local
+git clone	https://github.com/datagovuk/ckanext-dgu-local
 cd ckanext-dgu-local
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-ga-report
+git clone	https://github.com/datagovuk/ckanext-ga-report
 cd ckanext-ga-report
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-harvest
+git clone	https://github.com/datagovuk/ckanext-harvest
 cd ckanext-harvest
 git checkout 2.0
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-hierarchy
+git clone	https://github.com/datagovuk/ckanext-hierarchy
 cd ckanext-hierarchy
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-os
+git clone	https://github.com/datagovuk/ckanext-os
 cd ckanext-os
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-qa
+git clone	https://github.com/datagovuk/ckanext-qa
 cd ckanext-qa
 git checkout 2.0
 cd -
 
-git clone git@github.com:datagovuk/ckanext-report
+git clone https://github.com/datagovuk/ckanext-report
 cd ckanext-report
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-spatial
+git clone	https://github.com/datagovuk/ckanext-spatial
 cd ckanext-spatial
 git checkout dgu
 cd -
 
-git clone	git@github.com:datagovuk/ckanext-taxonomy
+git clone	https://github.com/datagovuk/ckanext-taxonomy
 cd ckanext-taxonomy
 git checkout master
 cd -
 
-git clone	git@github.com:okfn/ckanext-importlib
+git clone	https://github.com/okfn/ckanext-importlib
 cd ckanext-importlib
 git checkout master
 cd -
 
-git clone	git@github.com:datagovuk/shared_dguk_assets
+git clone	https://github.com/datagovuk/shared_dguk_assets
 cd shared_dguk_assets
 git checkout master
 cd -
 
-git clone   git@github.com:datagovuk/logreporter
+git clone   https://github.com/datagovuk/logreporter
 cd logreporter
 git checkout master
 cd -
 
-git clone   git@github.com:datagovuk/dgu_d7.git
+git clone   https://github.com/datagovuk/dgu_d7
 cd dgu_d7
 git checkout master
 cd -


### PR DESCRIPTION
Using git clone with HTTPS instead of SSH makes it easier to stand up systems without requiring them to have SSH keys on GitHub. This should close issue #98.